### PR TITLE
Use cmd args and output via stdout

### DIFF
--- a/rxjsdsl/discretetime/main.rkt
+++ b/rxjsdsl/discretetime/main.rkt
@@ -2,18 +2,14 @@
 
 #lang racket/base
 
+(require json)
 (require "api.rkt")
 (require "query.rkt")
 
 (define args (current-command-line-arguments))
-(define input-filename (vector-ref args 0))
-(define output-filename (vector-ref args 1))
 
-(define input-query (load-query-from-file input-filename))
+(define input-query (jsexpr->synth-query (string->jsexpr (vector-ref args 0))))
 
 (define result (make-synthesis-query input-query))
 
-(write-result-to-file output-filename result)
-
-(println "Success!")
-
+(displayln (jsexpr->string (query-result->jsexpr result)))


### PR DESCRIPTION
Changed CLI to take arguments as follows:

```
main.rkt "{\"bound\":4,\"input-count\":1,\"trace-list\":[{\"inputs\":[\"-13-7\"],\"output\":\"-24-8\"}],\"insn-count\":1}"
```

which outputs the following to stdout instead of a file

```
{"inputs":[],"candidates":1,"program1":"function synthedFunc(input0) { return input0.map(add1); }","program2":""}
```

this is because using files as input/output of a program is harder than using stdin/stdout node-based server.