### PR TITLE
Add symbolic performance repair

### DIFF
--- a/deepcoderdsl/model1/operators.rkt
+++ b/deepcoderdsl/model1/operators.rkt
@@ -5,7 +5,7 @@
 (require "model.rkt")
 
 (struct operator
-  (name call print) #:transparent)
+  (name call print) #:transparent #:mutable)
 
 (define (call-stream-insn op insn past-vars)
   ((operator-call op) insn past-vars))
@@ -179,7 +179,8 @@
 
 (define (zipwith-dc f xs1 xs2)
   (let ([xs-min (min (length xs1) (length xs2))])
-    (map f (take xs1 xs-min) (take xs2 xs-min))))
+    (for/all ([xs-min xs-min #:exhaustive])
+      (map f (take xs1 xs-min) (take xs2 xs-min)))))
 
 (define zipwith-dc-op
   (operator "zipwith-dc"


### PR DESCRIPTION
This PR adds a performance repair discovered by our tool for `deepcoderdsl`. It reduces the running time of:

`program1.rkt` from 5s to 4s
`program0.rkt` from 4s to 2s 

It did not negatively impact any other files.

This should not affect the correctness of the program. From a quick glance, the output after applying the repair looks the same.